### PR TITLE
Force image recreation during deployment

### DIFF
--- a/.github/ansible/deploy.yaml
+++ b/.github/ansible/deploy.yaml
@@ -35,5 +35,6 @@
   - name: run the copied compose file
     community.docker.docker_compose:
       project_src: /tmp/
+      recreate: always
       state: present
     become: true


### PR DESCRIPTION
The old pipeline brought down the containers and then brought them back up, without pulling the new images.
