### PR TITLE
Setup postman tests with GitHub actions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -89,20 +89,18 @@ jobs:
             [all]
             ${{secrets.SSH_HOST}} ansible_user=${{secrets.SSH_USER}}
 
+
   postman:
     needs: deploy
-
-    jobs:
-      automated-api-tests:
-        runs-on: ubuntu-latest
-        steps:
-          - uses: actions/checkout@v3
-          - name: Install Postman CLI
-            run: |
-              curl -o- "https://dl-cli.pstmn.io/install/linux64.sh" | sh
-          - name: Login to Postman CLI
-            run: postman login --with-api-key ${{ secrets.POSTMAN_API_KEY }}
-          - name: Run API tests
-            run: |
-              postman collection run "8945217-6624a47c-3fc2-4136-ab89-df49655d926f"
-      
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Postman CLI
+        run: |
+          curl -o- "https://dl-cli.pstmn.io/install/linux64.sh" | sh
+      - name: Login to Postman CLI
+        run: postman login --with-api-key ${{ secrets.POSTMAN_API_KEY }}
+      - name: Run API tests
+        run: |
+          postman collection run "8945217-6624a47c-3fc2-4136-ab89-df49655d926f"
+  

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -88,3 +88,21 @@ jobs:
           inventory: |
             [all]
             ${{secrets.SSH_HOST}} ansible_user=${{secrets.SSH_USER}}
+
+  postman:
+    needs: deploy
+
+    jobs:
+      automated-api-tests:
+        runs-on: ubuntu-latest
+        steps:
+          - uses: actions/checkout@v3
+          - name: Install Postman CLI
+            run: |
+              curl -o- "https://dl-cli.pstmn.io/install/linux64.sh" | sh
+          - name: Login to Postman CLI
+            run: postman login --with-api-key ${{ secrets.POSTMAN_API_KEY }}
+          - name: Run API tests
+            run: |
+              postman collection run "8945217-6624a47c-3fc2-4136-ab89-df49655d926f"
+      

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -37,3 +37,20 @@ jobs:
       - name: Test with pytest
         run: |
           python -m pytest --import-mode=append src/backend/
+  
+  postman:
+    needs: deploy
+
+    jobs:
+      automated-api-tests:
+        runs-on: ubuntu-latest
+        steps:
+          - uses: actions/checkout@v3
+          - name: Install Postman CLI
+            run: |
+              curl -o- "https://dl-cli.pstmn.io/install/linux64.sh" | sh
+          - name: Login to Postman CLI
+            run: postman login --with-api-key ${{ secrets.POSTMAN_API_KEY }}
+          - name: Run API tests
+            run: |
+              postman collection run "8945217-6624a47c-3fc2-4136-ab89-df49655d926f"

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -38,16 +38,4 @@ jobs:
         run: |
           python -m pytest --import-mode=append src/backend/
   
-
-  automated-api-tests:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install Postman CLI
-        run: |
-          curl -o- "https://dl-cli.pstmn.io/install/linux64.sh" | sh
-      - name: Login to Postman CLI
-        run: postman login --with-api-key ${{ secrets.POSTMAN_API_KEY }}
-      - name: Run API tests
-        run: |
-          postman collection run "8945217-6624a47c-3fc2-4136-ab89-df49655d926f"
+  

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -39,7 +39,6 @@ jobs:
           python -m pytest --import-mode=append src/backend/
   
   postman:
-    needs: deploy
 
     jobs:
       automated-api-tests:

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -38,18 +38,16 @@ jobs:
         run: |
           python -m pytest --import-mode=append src/backend/
   
-  postman:
 
-    jobs:
-      automated-api-tests:
-        runs-on: ubuntu-latest
-        steps:
-          - uses: actions/checkout@v3
-          - name: Install Postman CLI
-            run: |
-              curl -o- "https://dl-cli.pstmn.io/install/linux64.sh" | sh
-          - name: Login to Postman CLI
-            run: postman login --with-api-key ${{ secrets.POSTMAN_API_KEY }}
-          - name: Run API tests
-            run: |
-              postman collection run "8945217-6624a47c-3fc2-4136-ab89-df49655d926f"
+  automated-api-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Postman CLI
+        run: |
+          curl -o- "https://dl-cli.pstmn.io/install/linux64.sh" | sh
+      - name: Login to Postman CLI
+        run: postman login --with-api-key ${{ secrets.POSTMAN_API_KEY }}
+      - name: Run API tests
+        run: |
+          postman collection run "8945217-6624a47c-3fc2-4136-ab89-df49655d926f"


### PR DESCRIPTION
These are basically tests to see if the front page is still up (returns 200 and responds within 600 - 1000 milliseconds).

I tested it out by putting it in lint-and-test and it logs into Postman successfully and carries out the tests:
https://github.com/MinitwitGroupI/MiniTwit/actions/runs/4370959752/jobs/7646441714
 

I have not tested it out in deploy.yaml since it has not been merged with main and thus deployed. 

I have added "needs: deploy" but when deploy finishes does that mean:

1. when its last command has been executed
2. or is it when the container and thus the server is running again?

If it's 1 then Postman should be made to wait before it carries out its tests. 

The ideal would be that if there is an error then immediately rollback to the previous build as well as inform about the problem. One way to achieve this is with bash scripting by calling ```docker history <image_name>``` like here: https://gist.github.com/dasgoll/476ecc7a057ac885f0be. But I'm sure that there is a better way. 